### PR TITLE
Request to Merge

### DIFF
--- a/src/test/java/com/lmax/disruptor/SequencerTest.java
+++ b/src/test/java/com/lmax/disruptor/SequencerTest.java
@@ -3,6 +3,8 @@ package com.lmax.disruptor;
 import com.lmax.disruptor.dsl.ProducerType;
 import com.lmax.disruptor.support.DummyWaitStrategy;
 import com.lmax.disruptor.util.DaemonThreadFactory;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -52,6 +54,17 @@ public class SequencerTest
         }
     }
 
+    @Test
+    public void shouldThrowAssertionErrorIfTwoThreadsPublishToSingleProducer() throws InterruptedException
+    {
+        Sequencer sequencer = new SingleProducerSequencer(BUFFER_SIZE, new BlockingWaitStrategy());
+        Thread otherThread  = new Thread(sequencer::next);
+        otherThread.start();
+        otherThread.join();
+
+        assertThrows(AssertionError.class, sequencer::next);
+    }
+
     @ParameterizedTest
     @MethodSource("sequencerGenerator")
     public void shouldStartWithInitialValue(final Sequencer sequencer)
@@ -99,20 +112,22 @@ public class SequencerTest
         throws InterruptedException
     {
         sequencer.addGatingSequences(gatingSequence);
-        long sequence = sequencer.next(BUFFER_SIZE);
-        sequencer.publish(sequence - (BUFFER_SIZE - 1), sequence);
 
         final CountDownLatch waitingLatch = new CountDownLatch(1);
         final CountDownLatch doneLatch = new CountDownLatch(1);
 
         final long expectedFullSequence = Sequencer.INITIAL_CURSOR_VALUE + sequencer.getBufferSize();
-        assertThat(
-            sequencer.getHighestPublishedSequence(Sequencer.INITIAL_CURSOR_VALUE + 1, sequencer.getCursor()),
-            is(expectedFullSequence));
 
         executor.submit(
                 () ->
                 {
+                    long sequence = sequencer.next(BUFFER_SIZE);
+                    sequencer.publish(sequence - (BUFFER_SIZE - 1), sequence);
+
+                    assertThat(
+                            sequencer.getHighestPublishedSequence(Sequencer.INITIAL_CURSOR_VALUE + 1, sequencer.getCursor()),
+                            is(expectedFullSequence));
+
                     waitingLatch.countDown();
 
                     long next = sequencer.next();


### PR DESCRIPTION
### **PR Type**
enhancement, tests


___

### **Description**
- Enhanced `SingleProducerSequencer` by adding a mechanism to assert that only a single thread accesses it, using a private `Thread` field and the `sameThread()` method.
- Introduced assertions in the `next(int n)` method to detect incorrect usage of `ProducerType`.
- Added a new test in `SequencerTest` to verify that an `AssertionError` is thrown when two threads attempt to publish to a `SingleProducerSequencer`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SingleProducerSequencer.java</strong><dd><code>Add thread assertion to SingleProducerSequencer for single-thread </code><br><code>access</code></dd></summary>
<hr>

src/main/java/com/lmax/disruptor/SingleProducerSequencer.java

<li>Added a private <code>Thread</code> field to track the producer thread.<br> <li> Implemented <code>sameThread()</code> method to assert single-thread access.<br> <li> Added assertions in <code>next(int n)</code> to ensure single-thread access.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/disruptor/pull/1/files#diff-c651f28019f5b23c7780811087acec0400935d923e0b1cb76d54d416885e28da">+20/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SequencerTest.java</strong><dd><code>Add test for single-thread access assertion in SingleProducerSequencer</code></dd></summary>
<hr>

src/test/java/com/lmax/disruptor/SequencerTest.java

<li>Added a test to verify assertion error when two threads access <br>SingleProducerSequencer.<br> <li> Utilized JUnit assertions to test thread access.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/disruptor/pull/1/files#diff-fc71fbaeaf52215e95010d2a2dd501da3c1669f7bf19c1bc16cd0a271b752a67">+20/-5</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information